### PR TITLE
Export types needed to implement custom serializers.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,14 +14,14 @@ const stores : Stores = {
   session: {}
 }
 
-interface Serializer<T> {
+export interface Serializer<T> {
   parse(text: string): T
   stringify(object: T): string
 }
 
-type StorageType = 'local' | 'session'
+export type StorageType = 'local' | 'session'
 
-interface Options<T> {
+export interface Options<T> {
   serializer?: Serializer<T>
   storage?: StorageType
 }


### PR DESCRIPTION
Serializer and option types are not exported so you can't use the types or implement a serializer with typing