### PR TITLE
Persistency in cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # svelte-persisted-store
 
-A Svelte store that persists to local storage. Supports changes across multiple tabs.
+A Svelte store that persists to either local storage or cookies. Supports changes across multiple tabs for local storage.
 
 ## Installation
 
@@ -12,14 +12,15 @@ npm install svelte-persisted-store
 
 ## Usage
 
+### Local Storage store
 Define the store:
 
 ```javascript
-import { persisted } from 'svelte-persisted-store'
+import { localPersisted } from 'svelte-persisted-store'
 
 // First param `preferences` is the local storage key.
 // Second param is the initial value.
-export const preferences = persisted('preferences', {
+export const preferences = localPersisted('preferences', {
   theme: 'dark',
   pane: '50%',
   ...
@@ -45,11 +46,43 @@ You can also optionally set the `serializer` or `storage` type:
 import * as devalue from 'devalue'
 
 // third parameter is options.
-export const preferences = persisted('local-storage-key', 'default-value', {
+export const preferences = localPersisted('local-storage-key', 'default-value', {
   serializer: devalue, // defaults to `JSON`
   storage: 'session' // 'session' for sessionStorage, defaults to 'local'
 })
 ```
+
+### Cookie storage store
+The cookie storage stores the same as the local storage stores, except for when running server-side. On the server it needs to manually be initiated with the cookie value. Using SvelteKit, this can be done like the following example:
+
+```javascript
+// page.ts
+import type { PageLoad } from './$types';
+import { cookiePersisted } from 'svelte-persisted-store'
+
+export const load: PageLoad = ({ cookies }) => {
+  return {
+    preferences: cookiePersisted('preferences', JSON.parse(cookies.get('preferences')))
+  };
+};
+```
+
+As cookies also have a couple of different configuration paramaters, the configuration paramater of the cookie storage store exposes these:
+```javascript
+import { cookiePersisted } from 'svelte-persisted-store'
+
+// third parameter is options.
+export const preferences = cookiePersisted('local-storage-key', 'default-value', {
+  serializer: JSON,
+  cookieOptions: {
+    sameSite: 'Strict', // Default: "Strict"; Options: "Strict" | "Lax" | "None"
+    secure: true, // Default: true; Options: true | false
+    path: "/", // Default: "/"; Options: any string
+    expires: new Date(), // Default: A year from now; Options: Any date object
+  }
+})
+```
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ npm install svelte-persisted-store
 Define the store:
 
 ```javascript
-import { localPersisted } from 'svelte-persisted-store'
+import { persisted } from 'svelte-persisted-store'
 
 // First param `preferences` is the local storage key.
 // Second param is the initial value.
-export const preferences = localPersisted('preferences', {
+export const preferences = persisted('preferences', {
   theme: 'dark',
   pane: '50%',
   ...
@@ -46,9 +46,9 @@ You can also optionally set the `serializer` or `storage` type:
 import * as devalue from 'devalue'
 
 // third parameter is options.
-export const preferences = localPersisted('local-storage-key', 'default-value', {
+export const preferences = persisted('local-storage-key', 'default-value', {
   serializer: devalue, // defaults to `JSON`
-  storage: 'session' // 'session' for sessionStorage, defaults to 'local'
+  storage: 'session' // 'session' for sessionStorage or 'cookie' for storing in cookies, defaults to 'local'
 })
 ```
 
@@ -58,21 +58,22 @@ The cookie storage stores the same as the local storage stores, except for when 
 ```javascript
 // page.ts
 import type { PageLoad } from './$types';
-import { cookiePersisted } from 'svelte-persisted-store'
+import { persisted } from 'svelte-persisted-store'
 
 export const load: PageLoad = ({ cookies }) => {
   return {
-    preferences: cookiePersisted('preferences', JSON.parse(cookies.get('preferences')))
+    preferences: persisted('preferences', JSON.parse(cookies.get('preferences')), {storage: 'cookie'})
   };
 };
 ```
 
 As cookies also have a couple of different configuration paramaters, the configuration paramater of the cookie storage store exposes these:
 ```javascript
-import { cookiePersisted } from 'svelte-persisted-store'
+import { persisted } from 'svelte-persisted-store'
 
 // third parameter is options.
-export const preferences = cookiePersisted('local-storage-key', 'default-value', {
+export const preferences = persisted('local-storage-key', 'default-value', {
+  storage: 'cookie',
   serializer: JSON,
   cookieOptions: {
     sameSite: 'Strict', // Default: "Strict"; Options: "Strict" | "Lax" | "None"

--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,7 @@ export interface Serializer<T> {
 
 export type StorageType = 'local' | 'session'
 
-export interface Options<T> {
+export interface LocalStoreOptions<T> {
   serializer?: Serializer<T>
   storage?: StorageType
 }
@@ -31,18 +31,18 @@ function getStorage(type: StorageType) {
 }
 
 /** @deprecated `writable()` has been renamed to `localPersisted()` */
-export function writable<T>(key: string, initialValue: T, options?: Options<T>): Writable<T> {
+export function writable<T>(key: string, initialValue: T, options?: LocalStoreOptions<T>): Writable<T> {
   console.warn("writable() has been deprecated. Please use localPersisted() instead.\n\nchange:\n\nimport { writable } from 'svelte-persisted-store'\n\nto:\n\nimport { localPersisted } from 'svelte-persisted-store'")
   return localPersisted<T>(key, initialValue, options)
 }
 
 /** @deprecated `persisted()` has been renamed to `localPersisted()` */
-export function persisted<T>(key: string, initialValue: T, options?: Options<T>): Writable<T> {
+export function persisted<T>(key: string, initialValue: T, options?: LocalStoreOptions<T>): Writable<T> {
   console.warn("persisted() has been deprecated. Please use localPersisted() instead.\n\nchange:\n\nimport { persisted } from 'svelte-persisted-store'\n\nto:\n\nimport { localPersisted } from 'svelte-persisted-store'")
   return localPersisted<T>(key, initialValue, options)
 }
 
-export function localPersisted<T>(key: string, initialValue: T, options?: Options<T>): Writable<T> {
+export function localPersisted<T>(key: string, initialValue: T, options?: LocalStoreOptions<T>): Writable<T> {
   const serializer = options?.serializer ?? JSON
   const storageType = options?.storage ?? 'local'
   const browser = typeof (window) !== 'undefined' && typeof (document) !== 'undefined'

--- a/index.ts
+++ b/index.ts
@@ -62,16 +62,19 @@ function isBrowser(): boolean {
   return typeof (window) !== 'undefined' && typeof (document) !== 'undefined'
 }
 
-/** @deprecated `writable()` has been renamed to `localPersisted()` */
-export function writable<T>(key: string, initialValue: T, options?: LocalStoreOptions<T>): Writable<T> {
-  console.warn("writable() has been deprecated. Please use localPersisted() instead.\n\nchange:\n\nimport { writable } from 'svelte-persisted-store'\n\nto:\n\nimport { localPersisted } from 'svelte-persisted-store'")
-  return localPersisted<T>(key, initialValue, options)
+/** @deprecated `writable()` has been renamed to `persisted()` */
+export function writable<T>(key: string, initialValue: T, options?: CookieStoreOptions<T> | LocalStoreOptions<T>): Writable<T> {
+  console.warn("writable() has been deprecated. Please use persisted() instead.\n\nchange:\n\nimport { writable } from 'svelte-persisted-store'\n\nto:\n\nimport { persisted } from 'svelte-persisted-store'")
+  return persisted<T>(key, initialValue, options)
 }
 
-/** @deprecated `persisted()` has been renamed to `localPersisted()` */
-export function persisted<T>(key: string, initialValue: T, options?: LocalStoreOptions<T>): Writable<T> {
-  console.warn("persisted() has been deprecated. Please use localPersisted() instead.\n\nchange:\n\nimport { persisted } from 'svelte-persisted-store'\n\nto:\n\nimport { localPersisted } from 'svelte-persisted-store'")
-  return localPersisted<T>(key, initialValue, options)
+export function persisted<T>(key: string, initialValue: T, options?: CookieStoreOptions<T> | LocalStoreOptions<T>): Writable<T> {
+  if (!options)
+    return localPersisted<T>(key, initialValue)
+  else if (options.storage === "cookie")
+    return cookiePersisted(key, initialValue, options)
+  else
+    return localPersisted(key, initialValue, options)
 }
 
 export function localPersisted<T>(key: string, initialValue: T, options?: LocalStoreOptions<T>): Writable<T> {

--- a/index.ts
+++ b/index.ts
@@ -30,15 +30,22 @@ function getStorage(type: StorageType) {
   return type === 'local' ? localStorage : sessionStorage
 }
 
-/** @deprecated `writable()` has been renamed to `persisted()` */
+/** @deprecated `writable()` has been renamed to `localPersisted()` */
 export function writable<T>(key: string, initialValue: T, options?: Options<T>): Writable<T> {
-  console.warn("writable() has been deprecated. Please use persisted() instead.\n\nchange:\n\nimport { writable } from 'svelte-persisted-store'\n\nto:\n\nimport { persisted } from 'svelte-persisted-store'")
-  return persisted<T>(key, initialValue, options)
+  console.warn("writable() has been deprecated. Please use localPersisted() instead.\n\nchange:\n\nimport { writable } from 'svelte-persisted-store'\n\nto:\n\nimport { localPersisted } from 'svelte-persisted-store'")
+  return localPersisted<T>(key, initialValue, options)
 }
+
+/** @deprecated `persisted()` has been renamed to `localPersisted()` */
 export function persisted<T>(key: string, initialValue: T, options?: Options<T>): Writable<T> {
+  console.warn("persisted() has been deprecated. Please use localPersisted() instead.\n\nchange:\n\nimport { persisted } from 'svelte-persisted-store'\n\nto:\n\nimport { localPersisted } from 'svelte-persisted-store'")
+  return localPersisted<T>(key, initialValue, options)
+}
+
+export function localPersisted<T>(key: string, initialValue: T, options?: Options<T>): Writable<T> {
   const serializer = options?.serializer ?? JSON
   const storageType = options?.storage ?? 'local'
-  const browser = typeof(window) !== 'undefined' && typeof(document) !== 'undefined'
+  const browser = typeof (window) !== 'undefined' && typeof (document) !== 'undefined'
   const storage = browser ? getStorage(storageType) : null
 
   function updateStorage(key: string, value: T) {

--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,10 @@ function getStorage(type: StorageType) {
   return type === 'local' ? localStorage : sessionStorage
 }
 
+function isBrowser(): boolean {
+  return typeof (window) !== 'undefined' && typeof (document) !== 'undefined'
+}
+
 /** @deprecated `writable()` has been renamed to `localPersisted()` */
 export function writable<T>(key: string, initialValue: T, options?: LocalStoreOptions<T>): Writable<T> {
   console.warn("writable() has been deprecated. Please use localPersisted() instead.\n\nchange:\n\nimport { writable } from 'svelte-persisted-store'\n\nto:\n\nimport { localPersisted } from 'svelte-persisted-store'")
@@ -47,7 +51,7 @@ export function persisted<T>(key: string, initialValue: T, options?: LocalStoreO
 export function localPersisted<T>(key: string, initialValue: T, options?: LocalStoreOptions<T>): Writable<T> {
   const serializer = options?.serializer ?? JSON
   const storageType = options?.storage ?? 'local'
-  const browser = typeof (window) !== 'undefined' && typeof (document) !== 'undefined'
+  const browser = isBrowser()
   const storage = browser ? getStorage(storageType) : null
 
   function updateStorage(key: string, value: T) {

--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,31 @@ export interface LocalStoreOptions<T> {
   storage?: StorageType
 }
 
+export interface CookieOptions {
+  sameSite: "Strict" | "Lax" | "None"
+  secure: boolean
+  path: string
+  expires: Date
+}
+
+
+export interface CookieStoreOptions<T> {
+  serializer?: Serializer<T>
+  cookieOptions?: CookieOptions
+}
+
+export function getDefaultCookieOptions(): CookieOptions {
+  const expires = new Date()
+  expires.setFullYear(expires.getFullYear() + 1)
+
+  return {
+    sameSite: 'Strict',
+    secure: true,
+    path: "/",
+    expires
+  }
+}
+
 function getStorage(type: StorageType) {
   return type === 'local' ? localStorage : sessionStorage
 }

--- a/index.ts
+++ b/index.ts
@@ -21,13 +21,6 @@ export interface Serializer<T> {
   stringify(object: T): string
 }
 
-export type StorageType = 'local' | 'session'
-
-export interface LocalStoreOptions<T> {
-  serializer?: Serializer<T>
-  storage?: StorageType
-}
-
 export interface CookieOptions {
   sameSite: "Strict" | "Lax" | "None"
   secure: boolean
@@ -35,9 +28,17 @@ export interface CookieOptions {
   expires: Date
 }
 
-
-export interface CookieStoreOptions<T> {
+export interface StoreOptions<T> {
   serializer?: Serializer<T>
+  storage: 'local' | 'session' | 'cookie'
+}
+
+export interface LocalStoreOptions<T> extends StoreOptions<T> {
+  storage: 'local' | 'session'
+}
+
+export interface CookieStoreOptions<T> extends StoreOptions<T> {
+  storage: 'cookie'
   cookieOptions?: CookieOptions
 }
 
@@ -53,7 +54,7 @@ export function getDefaultCookieOptions(): CookieOptions {
   }
 }
 
-function getStorage(type: StorageType) {
+function getStorage(type: 'local' | 'session') {
   return type === 'local' ? localStorage : sessionStorage
 }
 

--- a/index.ts
+++ b/index.ts
@@ -7,11 +7,13 @@ declare type StoreDict<T> = { [key: string]: Writable<T> }
 interface Stores {
   local: StoreDict<any>,
   session: StoreDict<any>,
+  cookie: StoreDict<any>,
 }
 
-const stores : Stores = {
+const stores: Stores = {
   local: {},
-  session: {}
+  session: {},
+  cookie: {},
 }
 
 export interface Serializer<T> {

--- a/index.ts
+++ b/index.ts
@@ -164,7 +164,7 @@ export function cookiePersisted<T>(key: string, initialValue: T, options?: Cooki
 
     store.subscribe((value) => setCookie(key, value))
 
-    return store
+    stores.cookie[key] = store
   }
 
   return stores.cookie[key]


### PR DESCRIPTION
So I implemented a base for implementing cookie-based persistent stores as described in #212. It has yet to work automatically on the server-side (it has to be manually instantiated with the value from the cookie in the request - see README for details), but between SvelteKit shared server-state, svelte context, NodeJS specific features, I didn't find a good way to do it. It also doesn't currently update the store if the cookies get updated from another tab, as there's no client-side events being fired when the cookies change.