### PR TITLE
Catch error when writting to local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ get(preferences) // read value
 $preferences // read value with automatic subscription
 ```
 
-You can also optionally set the `serializer`, `storage` and `onStoreError` type:
+You can also optionally set the `serializer`, `storage` and `onError` type:
 
 ```javascript
 import * as devalue from 'devalue'
@@ -49,7 +49,7 @@ export const preferences = persisted('local-storage-key', 'default-value', {
   serializer: devalue, // defaults to `JSON`
   storage: 'session', // 'session' for sessionStorage, defaults to 'local'
   syncTabs: true // choose wether to sync localStorage across tabs, default is true
-  onStoreError: (e) => {/* Do something */} // Defaults to console.error with the error object
+  onError: (e) => {/* Do something */} // Defaults to console.error with the error object
 })
 ```
 
@@ -57,7 +57,7 @@ As the library will swallow errors encountered when reading from browser storage
 
 ```javascript
 export const preferences = persisted('local-storage-key', 'default-value', {
-  onStoreError: (e) => {
+  onError: (e) => {
     throw e
   }
 })

--- a/README.md
+++ b/README.md
@@ -39,10 +39,7 @@ get(preferences) // read value
 $preferences // read value with automatic subscription
 ```
 
-You can set a couple of options:
-- `serializer` or `storage` type
-- Whether to catch errors when writing to session/local storage (or just re-throw them)
-- Specify a function to be called when encountering error
+You can also optionally set the `serializer`, `storage` and `onStoreError` type:
 
 ```javascript
 import * as devalue from 'devalue'
@@ -52,8 +49,17 @@ export const preferences = persisted('local-storage-key', 'default-value', {
   serializer: devalue, // defaults to `JSON`
   storage: 'session', // 'session' for sessionStorage, defaults to 'local'
   syncTabs: true // choose wether to sync localStorage across tabs, default is true
-  catchError: true, // defaults to true
-  onStoreError: (e) => {/* Do something */}
+  onStoreError: (e) => {/* Do something */} // Defaults to console.error with the error object
+})
+```
+
+As the library will swallow errors encountered when reading from browser storage it is possible to specify a custom function to handle the error. Should the swallowing not be desirable, it is possible to re-throw the error like the following example (not recommended):
+
+```javascript
+export const preferences = persisted('local-storage-key', 'default-value', {
+  onStoreError: (e) => {
+    throw e
+  }
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ get(preferences) // read value
 $preferences // read value with automatic subscription
 ```
 
-You can also optionally set the `serializer` or `storage` type:
+You can also optionally set the `serializer` or `storage` type, and whether to catch errors when writing to session/local storage:
 
 ```javascript
 import * as devalue from 'devalue'
@@ -49,6 +49,7 @@ export const preferences = persisted('local-storage-key', 'default-value', {
   serializer: devalue, // defaults to `JSON`
   storage: 'session', // 'session' for sessionStorage, defaults to 'local'
   syncTabs: true // choose wether to sync localStorage across tabs, default is true
+  catchError: true // defaults to true
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ get(preferences) // read value
 $preferences // read value with automatic subscription
 ```
 
-You can also optionally set the `serializer` or `storage` type, and whether to catch errors when writing to session/local storage:
+You can set a couple of options:
+- `serializer` or `storage` type
+- Whether to catch errors when writing to session/local storage (or just re-throw them)
+- Specify a function to be called when encountering error
 
 ```javascript
 import * as devalue from 'devalue'
@@ -49,7 +52,8 @@ export const preferences = persisted('local-storage-key', 'default-value', {
   serializer: devalue, // defaults to `JSON`
   storage: 'session', // 'session' for sessionStorage, defaults to 'local'
   syncTabs: true // choose wether to sync localStorage across tabs, default is true
-  catchError: true // defaults to true
+  catchError: true, // defaults to true
+  onStoreError: (e) => {/* Do something */}
 })
 ```
 

--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,7 @@ export interface Options<T> {
   serializer?: Serializer<T>
   storage?: StorageType,
   syncTabs: boolean,
-  onStoreError?: (e: unknown) => void
+  onError?: (e: unknown) => void
 }
 
 function getStorage(type: StorageType) {
@@ -41,7 +41,7 @@ export function persisted<T>(key: string, initialValue: T, options?: Options<T>)
   const serializer = options?.serializer ?? JSON
   const storageType = options?.storage ?? 'local'
   const syncTabs = options?.syncTabs ?? true
-  const onStoreError = options?.onStoreError ?? ((e) => console.error(`Error when writing value from persisted store "${key}" to ${storageType}`, e))
+  const onError = options?.onError ?? ((e) => console.error(`Error when writing value from persisted store "${key}" to ${storageType}`, e))
   const browser = typeof (window) !== 'undefined' && typeof (document) !== 'undefined'
   const storage = browser ? getStorage(storageType) : null
 
@@ -49,7 +49,7 @@ export function persisted<T>(key: string, initialValue: T, options?: Options<T>)
     try {
       storage?.setItem(key, serializer.stringify(value))
     } catch (e) {
-      onStoreError(e)
+      onError(e)
     }
   }
 

--- a/index.ts
+++ b/index.ts
@@ -71,8 +71,8 @@ export function persisted<T>(key: string, initialValue: T, options?: Options<T>)
 
     stores[storageType][key] = {
       set(value: T) {
-        updateStorage(key, value)
         set(value)
+        updateStorage(key, value)
       },
       update(callback: Updater<T>) {
         return store.update((last) => {

--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,7 @@ export interface Options<T> {
   storage?: StorageType,
   syncTabs: boolean,
   catchError?: boolean
+  onStoreError?: (e: unknown) => void
 }
 
 function getStorage(type: StorageType) {
@@ -42,6 +43,7 @@ export function persisted<T>(key: string, initialValue: T, options?: Options<T>)
   const storageType = options?.storage ?? 'local'
   const syncTabs = options?.syncTabs ?? true
   const catchError = options?.catchError ?? true
+  const onStoreError = options?.onStoreError ?? (() => { })
   const browser = typeof (window) !== 'undefined' && typeof (document) !== 'undefined'
   const storage = browser ? getStorage(storageType) : null
 
@@ -51,7 +53,9 @@ export function persisted<T>(key: string, initialValue: T, options?: Options<T>)
     } catch (e) {
       if (catchError) {
         console.error(`Error when writing value from persisted store "${key}" to ${storageType} storage`, e)
+        onStoreError(e)
       } else {
+        onStoreError(e)
         throw e
       }
     }

--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,6 @@ export interface Options<T> {
   serializer?: Serializer<T>
   storage?: StorageType,
   syncTabs: boolean,
-  catchError?: boolean
   onStoreError?: (e: unknown) => void
 }
 
@@ -42,8 +41,7 @@ export function persisted<T>(key: string, initialValue: T, options?: Options<T>)
   const serializer = options?.serializer ?? JSON
   const storageType = options?.storage ?? 'local'
   const syncTabs = options?.syncTabs ?? true
-  const catchError = options?.catchError ?? true
-  const onStoreError = options?.onStoreError ?? (() => { })
+  const onStoreError = options?.onStoreError ?? ((e) => console.error(`Error when writing value from persisted store "${key}" to ${storageType}`, e))
   const browser = typeof (window) !== 'undefined' && typeof (document) !== 'undefined'
   const storage = browser ? getStorage(storageType) : null
 
@@ -51,13 +49,7 @@ export function persisted<T>(key: string, initialValue: T, options?: Options<T>)
     try {
       storage?.setItem(key, serializer.stringify(value))
     } catch (e) {
-      if (catchError) {
-        console.error(`Error when writing value from persisted store "${key}" to ${storageType} storage`, e)
-        onStoreError(e)
-      } else {
-        onStoreError(e)
-        throw e
-      }
+      onStoreError(e)
     }
   }
 

--- a/test/domExceptions.test.ts
+++ b/test/domExceptions.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @vitest-environment jsdom
+ * @vitest-environment-options { "storageQuota": "0" }
+ */
+
+import { persisted } from '../index'
+import { expect, vi, beforeEach, describe, it } from 'vitest'
+
+beforeEach(() => localStorage.clear())
+
+describe('persisted()', () => {
+
+  it('logs error encountered when saving to local storage', () => {
+    const consoleMock = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const store = persisted('myKey', 'myVal')
+
+    store.set("myNewVal")
+
+    expect(consoleMock).toHaveBeenCalledWith("Error when writing value from persisted store \"myKey\" to local", new DOMException)
+    consoleMock.mockReset();
+  })
+
+  it('calls custom error function', () => {
+    const mockFunc = vi.fn()
+
+    const store = persisted('myKey2', 'myVal', { onError: mockFunc })
+    store.set("myNewVal")
+
+    expect(mockFunc).toHaveBeenCalledOnce()
+  })
+})

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -1,5 +1,6 @@
 import { persisted, writable } from '../index'
 import { get } from 'svelte/store'
+import { expect, vi, beforeEach, describe, test, it } from 'vitest'
 
 beforeEach(() => localStorage.clear())
 
@@ -193,7 +194,7 @@ describe('persisted()', () => {
 
     it('ignores session-backed stores', () => {
       const store = persisted('myKey10', 1, { storage: 'session' })
-      const values = []
+      const values: number[] = []
 
       const unsub = store.subscribe((value) => {
         values.push(value)


### PR DESCRIPTION
Sometimes writing to local storage will throw an error (fx. when the storage qouta is filled, it will throw "DOMException: The quota has been exceeded."). With the current codebase, this prevents the changes from reaching the store, essentially "blocking" the action. As this library is a layer on-top of the standard svelte store, this might come very unexpected for the developers using the lib, and potentially break their application. To fix it, I have taken the following approaches:

- Write to the store first, and then write to local storage. There's (in my mind at least) no reason why writing to local storage should come first, as that action would then block the browser from rendering the new UI based on the store changes, and if an error occurs, this would prevent the new value from reaching the store.
- Catch the error. There has been added a config option to allow the user to choose whether the error should be caught or not (defaults to true)