### PR TITLE
Fix: Load initial value from storage

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -53,14 +53,19 @@ export function persisted<T>(key: string, initialValue: T, options?: Options<T>)
     }
   }
 
+  function maybeLoadInitial(): T {
+    const json = storage?.getItem(key)
+
+    if (json) {
+      return <T>serializer.parse(json)
+    }
+
+    return initialValue
+  }
+
   if (!stores[storageType][key]) {
-    const store = internal(initialValue, (set) => {
-      const json = storage?.getItem(key)
-
-      if (json) {
-        set(<T>serializer.parse(json))
-      }
-
+    const initial = maybeLoadInitial()
+    const store = internal(initial, (set) => {
       if (browser && storageType == 'local' && syncTabs) {
         const handleStorage = (event: StorageEvent) => {
           if (event.key === key)

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -76,6 +76,14 @@ describe('persisted()', () => {
       expect(localStorage.myKey6).toEqual('124')
       expect(value).toEqual(124)
     })
+
+    test("BUG: update should use existing value", () => {
+      localStorage.setItem('myKey6b', '12345')
+      const store = persisted('myKey6b', 123)
+      store.update(n => { n += 1; return n })
+
+      expect(localStorage.myKey6b).toEqual('12346')
+    })
   })
 
   describe('subscribe()', () => {

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -184,12 +184,13 @@ describe('persisted()', () => {
     })
 
     it("doesn't update store when there are no subscribers", () => {
-      const store = persisted('myKey', 1)
+      localStorage.setItem('myKeyb', '2')
+
+      const store = persisted('myKeyb', 1)
       const values: number[] = []
 
-      const event = new StorageEvent('storage', {key: 'myKey', newValue: '2'})
+      const event = new StorageEvent('storage', {key: 'myKeyb', newValue: '2'})
       window.dispatchEvent(event)
-      localStorage.setItem('myKey', '2')
 
       const unsub = store.subscribe((value: number) => {
         values.push(value)


### PR DESCRIPTION
This fixes a bug where the initial value set incorrectly. Closes #231

Previously, it only read the initial value inside store's closure:

```javascript
writable(initialValue, set => {
  // read from storage *inside* closure
  const json = storage.getItem(key)
  const existingValue = JSON.parse(parsedValue)
  
  // ...
})
```

But that closure is only called on first get.

Instead, the initial read should happen before the store is even created:


```javascript
// read from storage **outside** closure, before initializing store
const json = storage.getItem(key)
const initialOrExisting = json ? JSON.parse(json) : initialValue

writable(initialOrExisting, set => {
  // ...
})
```
