### PR TITLE
Implementing beforeRead and beforeWrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ export const preferences = persisted('local-storage-key', 'default-value', {
   syncTabs: true, // choose whether to sync localStorage across tabs, default is true
   onWriteError: (error) => {/* handle or rethrow */}, // Defaults to console.error with the error object
   onParseError: (raw, error) => {/* handle or rethrow */}, // Defaults to console.error with the error object
+  beforeRead: (value) => {/* change value after serialization but before setting store to return value*/},
+  beforeWrite: (value) => {/* change value after writing to store, but before writing return value to local storage*/},
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ export const preferences = persisted('local-storage-key', 'default-value', {
   syncTabs: true, // choose whether to sync localStorage across tabs, default is true
   onWriteError: (error) => {/* handle or rethrow */}, // Defaults to console.error with the error object
   onParseError: (raw, error) => {/* handle or rethrow */}, // Defaults to console.error with the error object
-  beforeRead: (value) => {/* change value after serialization but before setting store to return value*/},
-  beforeWrite: (value) => {/* change value after writing to store, but before writing return value to local storage*/},
+  beforeRead: (value, cancel) => {/* change value after serialization but before setting store to return value. Return cancel to cancel the operation*/},
+  beforeWrite: (value, cancel) => {/* change value after writing to store, but before writing return value to local storage. Return cancel to cancel the operation*/},
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ export const preferences = persisted('local-storage-key', 'default-value', {
   syncTabs: true, // choose whether to sync localStorage across tabs, default is true
   onWriteError: (error) => {/* handle or rethrow */}, // Defaults to console.error with the error object
   onParseError: (raw, error) => {/* handle or rethrow */}, // Defaults to console.error with the error object
-  beforeRead: (value) => {/* change value after serialization but before setting store to return value. Return cancel to cancel the operation*/},
-  beforeWrite: (value) => {/* change value after writing to store, but before writing return value to local storage. Return cancel to cancel the operation*/},
+  beforeRead: (value) => {/* change value after serialization but before setting store to return value*/},
+  beforeWrite: (value) => {/* change value after writing to store, but before writing return value to local storage*/},
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ export const preferences = persisted('local-storage-key', 'default-value', {
   syncTabs: true, // choose whether to sync localStorage across tabs, default is true
   onWriteError: (error) => {/* handle or rethrow */}, // Defaults to console.error with the error object
   onParseError: (raw, error) => {/* handle or rethrow */}, // Defaults to console.error with the error object
-  beforeRead: (value, cancel) => {/* change value after serialization but before setting store to return value. Return cancel to cancel the operation*/},
-  beforeWrite: (value, cancel) => {/* change value after writing to store, but before writing return value to local storage. Return cancel to cancel the operation*/},
+  beforeRead: (value) => {/* change value after serialization but before setting store to return value. Return cancel to cancel the operation*/},
+  beforeWrite: (value) => {/* change value after writing to store, but before writing return value to local storage. Return cancel to cancel the operation*/},
 })
 ```
 

--- a/index.ts
+++ b/index.ts
@@ -77,10 +77,10 @@ export function persisted<T>(key: string, initialValue: T, options?: Options<T>)
     const store = internal(initial, (set) => {
       if (browser && storageType == 'local' && syncTabs) {
         const handleStorage = (event: StorageEvent) => {
-          if (event.key === key) {
+          if (event.key === key && event.newValue) {
             let newVal: any
             try {
-              newVal = event.newValue ? serializer.parse(event.newValue) : null
+              newVal = serializer.parse(event.newValue)
             } catch (e) {
               onParseError(event.newValue, e)
               return

--- a/index.ts
+++ b/index.ts
@@ -37,11 +37,11 @@ function getStorage(type: StorageType) {
 }
 
 /** @deprecated `writable()` has been renamed to `persisted()` */
-export function writable<StoreType, SerializerType>(key: string, initialValue: StoreType, options?: Options<StoreType, SerializerType>): Writable<StoreType> {
+export function writable<StoreType, SerializerType = StoreType>(key: string, initialValue: StoreType, options?: Options<StoreType, SerializerType>): Writable<StoreType> {
   console.warn("writable() has been deprecated. Please use persisted() instead.\n\nchange:\n\nimport { writable } from 'svelte-persisted-store'\n\nto:\n\nimport { persisted } from 'svelte-persisted-store'")
   return persisted<StoreType, SerializerType>(key, initialValue, options)
 }
-export function persisted<StoreType, SerializerType>(key: string, initialValue: StoreType, options?: Options<StoreType, SerializerType>): Writable<StoreType> {
+export function persisted<StoreType, SerializerType = StoreType>(key: string, initialValue: StoreType, options?: Options<StoreType, SerializerType>): Writable<StoreType> {
   if (options?.onError) console.warn("onError has been deprecated. Please use onWriteError instead")
 
   const serializer = options?.serializer ?? JSON

--- a/index.ts
+++ b/index.ts
@@ -28,8 +28,8 @@ export interface Options<StoreType, SerializerType> {
   onError?: (e: unknown) => void
   onWriteError?: (e: unknown) => void
   onParseError?: (newValue: string | null, e: unknown) => void
-  beforeRead?: <S extends symbol>(val: SerializerType, cancel: S) => StoreType | S
-  beforeWrite?: <S extends symbol>(val: StoreType, cancel: S) => SerializerType | S
+  beforeRead?: (val: SerializerType) => StoreType
+  beforeWrite?: (val: StoreType) => SerializerType
 }
 
 function getStorage(type: StorageType) {
@@ -57,9 +57,7 @@ export function persisted<StoreType, SerializerType>(key: string, initialValue: 
   const storage = browser ? getStorage(storageType) : null
 
   function updateStorage(key: string, value: StoreType) {
-    const cancel = Symbol("cancel")
-    const newVal = beforeWrite(value, cancel)
-    if (newVal === cancel) return
+    const newVal = beforeWrite(value)
 
     try {
       storage?.setItem(key, serializer.stringify(newVal))
@@ -82,9 +80,7 @@ export function persisted<StoreType, SerializerType>(key: string, initialValue: 
     const serialized = serialize(json)
     if (serialized == null) return initialValue
 
-    const cancel = Symbol("cancel")
-    const newVal = beforeRead(serialized, cancel)
-    if (newVal === cancel) return initialValue
+    const newVal = beforeRead(serialized)
     return newVal
   }
 
@@ -101,9 +97,7 @@ export function persisted<StoreType, SerializerType>(key: string, initialValue: 
               onParseError(event.newValue, e)
               return
             }
-            const cancel = Symbol("cancel")
-            const processedVal = beforeRead(newVal, cancel)
-            if (processedVal === cancel) return
+            const processedVal = beforeRead(newVal)
 
             set(processedVal)
           }

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -138,7 +138,7 @@ describe('persisted()', () => {
       const store = persisted("beforeRead-init-test", 0, { beforeRead: (v) => v * 2 })
       expect(get(store)).toEqual(4)
     })
-    it("allows modfiying value before reading upon event", () => {
+    it("allows modifying value before reading upon event", () => {
       const store = persisted("beforeRead-test", 0, { beforeRead: (v) => v * 2 })
       const values: number[] = []
 
@@ -154,7 +154,7 @@ describe('persisted()', () => {
       unsub()
     })
 
-    it("allows modfiying value before writing", () => {
+    it("allows modifying value before writing", () => {
       const store = persisted("beforeWrite-test", 0, { beforeWrite: (v) => v * 2 })
       store.set(2)
 

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -151,7 +151,7 @@ describe('persisted()', () => {
       unsub()
     })
 
-    it('sets store to null when value is null', () => {
+    it('ignores storages events when value is null', () => {
       const store = persisted('myKey9', {a: 1})
       const values: NumberDict[] = []
 
@@ -162,7 +162,7 @@ describe('persisted()', () => {
       const event = new StorageEvent('storage', {key: 'myKey9', newValue: null})
       window.dispatchEvent(event)
 
-      expect(values).toEqual([{a: 1}, null])
+      expect(values).toEqual([{a: 1}])
 
       unsub()
     })

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -132,6 +132,36 @@ describe('persisted()', () => {
     unsub2()
   })
 
+  describe("beforeRead and beforeWrite", () => {
+    it("allows modifying initial value before reading", () => {
+      localStorage.setItem("beforeRead-init-test", JSON.stringify(2))
+      const store = persisted("beforeRead-init-test", 0, { beforeRead: (v) => v * 2 })
+      expect(get(store)).toEqual(4)
+    })
+    it("allows modfiying value before reading upon event", () => {
+      const store = persisted("beforeRead-test", 0, { beforeRead: (v) => v * 2 })
+      const values: number[] = []
+
+      const unsub = store.subscribe((val: number) => {
+        values.push(val)
+      })
+
+      const event = new StorageEvent('storage', {key: 'beforeRead-test', newValue: "2"})
+      window.dispatchEvent(event)
+
+      expect(values).toEqual([0, 4])
+
+      unsub()
+    })
+
+    it("allows modfiying value before writing", () => {
+      const store = persisted("beforeWrite-test", 0, { beforeWrite: (v) => v * 2 })
+      store.set(2)
+
+      expect(JSON.parse(localStorage.getItem("beforeWrite-test") as string)).toEqual(4)
+    })
+  })
+
   describe('handles window.storage event', () => {
     type NumberDict = { [key: string] : number }
 

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -160,46 +160,6 @@ describe('persisted()', () => {
 
       expect(JSON.parse(localStorage.getItem("beforeWrite-test") as string)).toEqual(4)
     })
-
-    it("allows to cancel read operation during initialization", () => {
-      localStorage.setItem("beforeRead-init-cancel", JSON.stringify(2))
-      const beforeRead = vi.fn(<S extends symbol>(_: any, cancel: S) => cancel)
-      const store = persisted("beforeRead-init-cancel", 0, { beforeRead })
-      expect(beforeRead).toHaveBeenCalledOnce()
-      expect(get(store)).toEqual(0)
-    })
-
-    it("allows to cancel read operation during event handling", () => {
-      // Will only call beforeRead on init if key exists, so creates key
-      localStorage.setItem("beforeRead-cancel", JSON.stringify(2))
-
-      const beforeRead = vi.fn(<S extends symbol>(_: any, cancel: S) => cancel)
-      const store = persisted("beforeRead-cancel", 0, { beforeRead })
-
-      const values: number[] = []
-
-      const unsub = store.subscribe((val: number) => {
-        values.push(val)
-      })
-
-      const event = new StorageEvent('storage', { key: 'beforeRead-cancel', newValue: "2" })
-      window.dispatchEvent(event)
-
-      expect(beforeRead).toHaveBeenCalledTimes(2)
-      expect(values).toEqual([0])
-
-      unsub()
-    })
-
-    it("allows to cancel write operation", () => {
-      const beforeWrite = vi.fn(<S extends symbol>(_: number, cancel: S) => cancel)
-      const store = persisted<number, number>("beforeWrite-cancel", 0, { beforeWrite })
-      store.set(2)
-
-      expect(JSON.parse(localStorage.getItem("beforeWrite-cancel") as string)).toEqual(null)
-      expect(get(store)).toEqual(2)
-      expect(beforeWrite).toHaveBeenCalledOnce()
-    })
   })
 
   describe('handles window.storage event', () => {

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -289,7 +289,7 @@ describe('persisted()', () => {
 
     it("doesn't update, when syncTabs option is disabled", () => {
       const store = persisted('myKey13', 1, { syncTabs: false })
-      const values = []
+      const values: number[] = []
 
       const unsub = store.subscribe((value) => {
         values.push(value)

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -135,11 +135,11 @@ describe('persisted()', () => {
   describe("beforeRead and beforeWrite", () => {
     it("allows modifying initial value before reading", () => {
       localStorage.setItem("beforeRead-init-test", JSON.stringify(2))
-      const store = persisted("beforeRead-init-test", 0, { beforeRead: (v) => v * 2 })
+      const store = persisted("beforeRead-init-test", 0, { beforeRead: (v: number) => v * 2 })
       expect(get(store)).toEqual(4)
     })
     it("allows modifying value before reading upon event", () => {
-      const store = persisted("beforeRead-test", 0, { beforeRead: (v) => v * 2 })
+      const store = persisted("beforeRead-test", 0, { beforeRead: (v: number) => v * 2 })
       const values: number[] = []
 
       const unsub = store.subscribe((val: number) => {
@@ -193,7 +193,7 @@ describe('persisted()', () => {
 
     it("allows to cancel write operation", () => {
       const beforeWrite = vi.fn(<S extends symbol>(_: number, cancel: S) => cancel)
-      const store = persisted<number>("beforeWrite-cancel", 0, { beforeWrite })
+      const store = persisted<number, number>("beforeWrite-cancel", 0, { beforeWrite })
       store.set(2)
 
       expect(JSON.parse(localStorage.getItem("beforeWrite-cancel") as string)).toEqual(null)


### PR DESCRIPTION
Implemented the beforeRead and beforeWrite methods described in https://github.com/joshnuss/svelte-persisted-store/issues/244. When considering this PR it's important to have the following in mind:

The type of the data stored in localStorage may no longer be the same or even have the same shape as the data stored in the store with the corresponding key. This is absolutely intentional, but it does bring some "quirks" when it comes to stuff like typing, as the data shapes may be different:

- The input shape to the serializer stringify function and the output shape from the serializer stringify function is now no longer the shape of content of the store, but rather any, as the functions beforeRead and beforeWrite are intended to be used to transform the data into the shape of the store, but it is worth keeping in mind that the serializer functions are now typed with any instead of a specific shape
- This does however bring some interesting possibilities like storing a version number only in the localStorage and the use these proxy functions (beforeRead and beforeWrite) to not only validate this version number, but to strip it if it isn't of use for the application

It should also be noted, that as discussed in https://github.com/joshnuss/svelte-persisted-store/issues/244#issuecomment-2066114385, I have removed the behavior where the store contents would be set to null if the storage event contents are null. As mentioned by https://github.com/joshnuss/svelte-persisted-store/issues/244#issuecomment-2071318361 this is a type check specifically to ensure that the value of the event isn't null (and it's important), but the correct response here should be to avoid a null value