### PR TITLE
feat: Add reset method to persisted store

### DIFF
--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -86,6 +86,18 @@ describe('persisted()', () => {
     })
   })
 
+  describe('reset', () => {
+    it('resets to initial value', () => {
+      const store = persisted('myKey14', 123);
+      store.set(456);
+      store.reset();
+      const value = get(store);
+
+      expect(value).toEqual(123);
+      expect(localStorage.myKey14).toEqual('123');
+      });
+    });
+
   describe('subscribe()', () => {
     it('publishes updates', () => {
       const store = persisted('myKey7', 123)


### PR DESCRIPTION
Implemented the `reset` method for the persisted store as described in issue #263. This method discards all changes and resets both the store and the `localStorage` value to the `initialValue` provided.

Key changes include:

- Introduced a new `Persisted` type that extends the `Writable` interface with a `reset()` method.
- Added the `reset()` method to the store object.